### PR TITLE
Add a project poster template

### DIFF
--- a/project-posters/cladetime.md
+++ b/project-posters/cladetime.md
@@ -1,0 +1,128 @@
+# Project Poster: Cladetime
+
+## 📋 Overview
+
+### Onwership and status
+
+- Date: 2024-12-11
+
+- Owner: Evan
+
+- Team: Becky, Ben, Evan
+
+- Status: in progress
+
+## ❓ Problem space
+
+### What are we doing?
+
+Developing a reproducible way to use historic phylogenetic
+[reference trees](https://docs.nextstrain.org/projects/nextclade/en/stable/user/terminology.html#reference-tree-concept)
+to categorize Genbank-based SARS-CoV-2 genome data into clades.
+
+### How does this project fit into your broader strategy?
+
+Specifically, we need Cladetime to support the new
+[variant-nowcast-hub](https://github.com/reichlab/variant-nowcast-hub)
+created by the Reich Lab and the CDC.
+
+More broadly, the ability to classify SARS-CoV-2 sequences into clades using
+prior reference trees will be required by other hubs that solicit clade-related
+COVID-19 predictions.
+
+### Why are we doing this?
+
+Reich Lab and the CDC have recently opened the
+[variant-nowcast-hub](https://github.com/reichlab/variant-nowcast-hub), where
+modelers predict the prevalence of SARS-CoV-2 clades.
+
+For each of the hub's modeling rounds, we will need to generate target data by:
+
+1. Retrieving current SARS-CoV-2 sequences 90 days after the round's
+opening date
+2. Assigning those sequences to clades using the reference tree that was
+effective as of the round opening date
+
+In other words, perform clade assignments by applying a historic
+reference tree to a current set of sequences.
+
+The clade assignment functionality provided by
+[Nextclade's CLI](https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli/reference.html#nextclade-run)
+does not support the use case of looking up past reference trees.
+
+### How do we judge success?
+
+A successful outcome is software that:
+
+- is open source
+- is installable via GitHub (at a minimum; preferablly installable from
+a package manager like cran or pip)
+- allows users to retrieve SARS-CoV-2 sequence and sequence metadata for a
+specific point in time and filter it based on collection date
+- allows users to specify a SARS-CoV-2 reference tree that was active at a
+specific point in time
+- provides an interface to the Nextclade CLI clade assignment feature that
+accepts the sequence and reference tree information from the prior two
+items and returns the corresponding clade assignments
+
+### What are possible solutions?
+
+We plan to use the aforementioned Nextclade CLI for doing clade assignments.
+The inputs required are reference sequence, reference tree, and sequences.
+
+All possible solutions will get the reference tree and reference sequence
+via the version of the Nextclade SARS-CoV-2
+[dataset](https://docs.nextstrain.org/projects/nextclade/en/stable/user/datasets.html)
+that corresponds to the desired reference tree date.
+
+Thus, possible solutions focus on determing the best data source for the
+sequence data and sequence metadata.
+
+Possible solutions:
+
+- Get sequences via
+[NCBI API](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/api/rest-api/#post-/virus/genome/download),
+reference tree from a Nextclade dataset (with a version that corresponds
+to the historic tree we want), and reference sequence returned as part of the
+reference tree JSON. Use `released_since` and `updated_since` API params to download
+a targeted subset of sequences.
+
+- Use Nextstrain's
+[remote input files](https://docs.nextstrain.org/projects/ncov/en/latest/reference/remote_inputs.html)
+to get sequences and sequence metadata. Get the reference tree and reference
+sequence via the version of the Nextclade SARS-CoV-2
+[dataset](https://docs.nextstrain.org/projects/nextclade/en/stable/user/datasets.html)
+that corresponds to the date of the reference tree we want to use for clade
+assignment.
+
+## ✅ Validation
+
+### What do we already know?
+
+- The variant nowcast hub has existing code that uses Nextstrain's remote input
+files to get sequence metadata (specifically, `metadata.tsv.zst`) to generate
+the list of clades to model for each round)
+- Nextstrain supports accessing their Genbank-based remote input files via
+publicly-accessible, versioned S3 buckets.
+- The above metadata contains sequence clades as assigned using the tree that
+was active on the file's publication date
+- Starting in August, 2024, Nextstrain began publishing metadata that
+explicitly states which Nextclade dataset version (_i.e._, reference tree)
+was used for each of their pipeline runs
+
+### What do we need to answer?
+
+This is a backfilled project poster, so we've already tracked down our
+answers (see above).
+
+## 👍 Ready to make it
+
+### Proposed solution
+
+A Python package that will do custom clade assignments:
+
+- using Nextstrain's remote input files as sources for Genbank SARS-CoV-2
+sequence data and metadata
+- using the reference tree and reference sequence included in the Nextclade
+dataset version that corresponds to the date of the desired tree
+- feeding the above inputs into Nextclade's clade assignment CLI

--- a/templates/project-poster-template.md
+++ b/templates/project-poster-template.md
@@ -22,6 +22,10 @@ What does the project propose to do?
 
 What is high-level goal of this project?
 
+### What are we _not_ trying to do?
+
+Optional: What is out-of-scope for this project? This is a place where you can set up boundaries and anti-aims that will help prevent scope creep. 
+
 ### How do we judge success?
 
 A list of outcomes that should be true for the project to be considered a

--- a/templates/project-poster-template.md
+++ b/templates/project-poster-template.md
@@ -1,0 +1,73 @@
+# Project Poster: [project name]
+
+- Date: [date posted is created]
+
+- Owner: [project or product owner]
+
+- Team: [individual team members]
+
+- Status: [draft | in progress | done]
+
+## ❓ Problem space
+
+The goal of this section is to explain why solving this problem matters
+by answering the prompts below. Ideally, the answers will be informed
+by input from Lab leadership, the Hubverse, users, and/or funders.
+
+### What are we doing?
+
+What does the project propose to do?
+
+### Why are we doing this?
+
+What is high-level goal of this project?
+
+### How do we judge success?
+
+A list of outcomes that should be true for the project to be considered a
+success. Be sure to focus on outcomes, not implementation details.
+
+### What are possible solutions?
+
+A high-level list of potential ways to meet the project's goals.
+
+## ✅ Validation
+
+This section is for listing assumptions that should be validated before
+kicking off a project. The answers to the prompts below may change over
+time, as the team gets more information.
+
+### What do we already know?
+
+A list of information required before starting the project.
+We already know the answers.
+
+### What do we need to answer?
+
+A list of information required before starting the project.
+We need to find the answers.
+
+## 👍 Ready to make it
+
+If, after defining the problem space and validating assumptions, the team
+decides to move forward with the project, this section is to document
+a proposed solution.
+
+Keep the answers to the prompts below brief--this document isn't
+inteded to be a detailed project plan.
+
+### Proposed solution
+
+1-2 sentences about the team's chosen approach for tackling the problem space.
+
+### Visualize the solution
+
+Optional. If there is a mockup, data dictionary, or other artifact that clarifies
+the project's implementation, you can put it here (or link to it).
+
+### Scale and scope
+
+A place to define items like:
+
+- Required team size
+- Required delivery date (if applicable)


### PR DESCRIPTION
This changeset adds a template to use for project
posters. This is adapted from "corporate world," so happy to make further changes that would make it more appropriate for the kind of work we do.

I've also included an example by trying to backfill a project poster for Cladetime. It's not a great example, to be honst--it's hard to write these things retrospectively.