### PR TITLE
[LDR] hubverse `target_keys` should contain a single value

### DIFF
--- a/decisions/2024-12-11-ldr-hubverse-target_keys.md
+++ b/decisions/2024-12-11-ldr-hubverse-target_keys.md
@@ -1,0 +1,64 @@
+# 2024-12-11 target keys should contain single value
+
+## Context
+
+This was discussed in the 2024-12-11 hubverse developer meeting.
+
+In `target_metadata`, we allow for `target_keys` to be multiple fields. E.g.,
+if a hub has 4 targets given by "incident hospitalizations", "cumulative
+hospitalizations", "incident cases", "cumulative cases", these could be
+represented by two variables called `inc_cum` \in `{"incident", "cumulative"}`
+and signal \in `{"hospitalizations", "cases"}`.
+
+Downstream analysis will benefit from having one column to use as a partitioning
+key.
+
+No hubs in public repositories use multiple `target_keys`; If any do, the
+switch from to one target key should be fairly simple.
+
+### Aims
+
+ - simplification of hub configuration and downstream parsing.
+
+### Anti-Aims
+
+ - disrupt operations for currently running hubs.
+
+## Decision
+
+We will communicate this decision over the hubverse mailing list, slack, and the
+GitHub discussions repository.
+
+If we find any hubs that use multiple target keys, we will provide support for
+them to transition to the updated schema.
+
+We will update our schemas to specify that `target_keys` should contain exactly
+one property if it is not `null`.
+
+We will increment the version of the schemas to v4.0.1.
+
+We will update the documentation to refelect this decision.
+
+### Other Options Considered
+
+ - Option: Not restricting the number of target keys
+   - PRO: current state of affairs, allows potential for nuanced targets
+   - CON: not currently supported in our downstream tools; would require extra
+     coding effort to support
+   - NEUTRAL: no hubs currently use multiple target keys
+
+## Status
+
+accepted (via meeting)
+
+## Consequences
+
+- POSITIVE: coding for downstream tools will be simpler and easier to maintain
+- NEGATIVE: any hubs that use multiple target keys will need to remain at the
+  schema version they currently use or migrate
+- NEUTRAL: schemas will be updated
+- NEUTRAL: documentation will be updated
+
+## Projects
+
+ - The hubverse (no project poster as of 2024-12-24)


### PR DESCRIPTION
I have added an LDR to reflect the decision made at the hubverse devteam meeting on 2024-12-11.

Here is the transcript of the discussion:

 - In target_metadata, we allow for target_keys to be multiple fields. (Evan)  E.g., if a hub has 4 targets given by “incident hospitalizations”, “cumulative hospitalizations”, “incident cases”, “cumulative cases”, these could be represented by two variables called inc_cum \in {“incident”, “cumulative”} and signal \in {“hospitalizations”, “cases”}.  Is it worth the coding effort downstream to support this, or should we just ask hubs to provide 1 target in 1 column
   - E.g. 1 column with values like: (“incident hosps”) or (“incident cases”)
   - E.g. 2 columns with values like (“incident” and “hosps”) or (“incident” and “cases”)
   - Lucie: Are there any hubs that are using the two column targets?
   - Becky: as we start to play with dashboards and downstream data, having one column is great to use as a partitioning key.
   - Lucie: it’s also fairly easy to switch from two to one.
   - Nick: to clarify, we’ve made a decision to change this?
   - Anna: no.Tthe only thing that we want to specify is that each target would contain a single value.
   - Becky: is the work here to create a new version of the schema and update the documentation?
   - Becky will create a ticket.
   - Evan: should we check in with existing hubs before we go ahead with this?
   - Nick: the right thing to do would be to send this to the mailing list.


I am recording this as an LDR so I can refer to this decision for communications


PRs are already underway:

- https://github.com/hubverse-org/schemas/issues/118
- https://github.com/hubverse-org/hubAdmin/pull/90
- https://github.com/hubverse-org/hubDocs/pull/227
