### PR TITLE
fix formatting in target time series proposal

### DIFF
--- a/decisions/2025-02-27-rfc-time-series-target-data.md
+++ b/decisions/2025-02-27-rfc-time-series-target-data.md
@@ -30,7 +30,7 @@
     - `"target_keys": { <name of task id variable> : <task id variable value> }`
   - Example for a hub that tracks covid cases, hospitalizations, and deaths, recorded via the "target" task id variable:
     EXAMPLE 1: multiple targets:
-    ```json
+    ```
     target_metadata: [
         {
             "target_id": "cases",
@@ -66,7 +66,7 @@ Then the time-series.csv would look like this
 
 EXAMPLE 2: one target, with `target_keys: null`
 
-```json
+```
 target_metadata: [
     {
         "target_id": "cases",

--- a/decisions/2025-02-27-rfc-time-series-target-data.md
+++ b/decisions/2025-02-27-rfc-time-series-target-data.md
@@ -29,6 +29,7 @@
   - Within each of those entries, there is a block that has the form
     - `"target_keys": { <name of task id variable> : <task id variable value> }`
   - Example for a hub that tracks covid cases, hospitalizations, and deaths, recorded via the "target" task id variable:
+    
     EXAMPLE 1: multiple targets:
     ```
     target_metadata: [
@@ -52,30 +53,30 @@
         }
     ]
     ```
+    
+    Then the time-series.csv would look like this
 
-Then the time-series.csv would look like this
-
-| as_of | target | date | location | observation |
-| :---- | :---- | :---- | :---- | :---- |
-|  | cases |  |  |  |
-|  | cases |  |  |  |
-|  | … |  |  |  |
-|  | deaths |  |  |  |
-|  | deaths |  |  |  |
-|  | … |  |  |  |
-
-EXAMPLE 2: one target, with `target_keys: null`
-
-```
-target_metadata: [
-    {
-        "target_id": "cases",
-         …,
-        "target_keys": null
-        …
-    }
-]
-```
+    | as_of | target | date | location | observation |
+    | :---- | :---- | :---- | :---- | :---- |
+    |  | cases |  |  |  |
+    |  | cases |  |  |  |
+    |  | … |  |  |  |
+    |  | deaths |  |  |  |
+    |  | deaths |  |  |  |
+    |  | … |  |  |  |
+    
+    EXAMPLE 2: one target, with `target_keys: null`
+    
+    ```
+    target_metadata: [
+        {
+            "target_id": "cases",
+             …,
+            "target_keys": null
+            …
+        }
+    ]
+    ```
 
 ## Validations
 

--- a/decisions/2025-02-27-rfc-time-series-target-data.md
+++ b/decisions/2025-02-27-rfc-time-series-target-data.md
@@ -3,8 +3,8 @@
 ## General idea/Aims/Requirements
 
 * Prescribe a file-location and \-format for time-series target data that can be validated and used to support dashboard visualization and potentially could be used for other purposes, such as modeling.
-* The format for time-series target data will apply to targets that are defined as “step-ahead” targets in the target-metadata and where the target\_type metadata field is one of “continuous” “discrete” “binary” or “compositional” (i.e. the observation is numeric). \[Note: other data, including time-series data, could be stored in target-data but all files whose name or path starts with “time-series\*” (or possibly “oracle-output\*”, depending on how we end up setting that up) will be subject to validation.\]
-* We define a time-series target-data standard for single files and hive-style partitions where the top-level partition is based on the as\_of date. In any situation where data are versioned using an “as\_of” partition or column, the full version must be made available, no support for “diffs” from previous versions will be supported.
+* The format for time-series target data will apply to targets that are defined as "step-ahead" targets in the target-metadata and where the target\_type metadata field is one of "continuous" "discrete" "binary" or "compositional" (i.e. the observation is numeric). \[Note: other data, including time-series data, could be stored in target-data but all files whose name or path starts with "time-series\*" (or possibly "oracle-output\*", depending on how we end up setting that up) will be subject to validation.\]
+* We define a time-series target-data standard for single files and hive-style partitions where the top-level partition is based on the as\_of date. In any situation where data are versioned using an "as\_of" partition or column, the full version must be made available, no support for "diffs" from previous versions will be supported.
 * All time-series target data files must either be .csv or .parquet. No mixing of file types will be allowed.
 * Validations are enforced based on properties of the target that can be read from the tasks.json file.
 * A target can be represented in a time-series file as long as the definition of that target-id is consistent across all rounds/tasks. For example, as long as the names of the task-id variables are the same across all rounds, then it is easy to understand which columns should be present in a time-series file. If those column names change, then it becomes more complicated to support.
@@ -13,13 +13,13 @@
 
 - One time-series.csv (or .parquet) file or partitioned data set contains all of the time-series target data that can be validated for numeric variables in the hub.
 - This file has the following columns:
-  - “as\_of”: optional, an ISO date that says when the data were available
+  - "as\_of": optional, an ISO date that says when the data were available
   - \[a subset of task-id variables\]
     - these variables define the unit of observation for each observed value
     - one task-id variable must be an ISO date, corresponding to the date of the observed event
     - initially, they just need to be task-id variables, and we will later implement a metadata field/validation about which task-id variables these are.
     - they must be readable as the data type for the task-id variable in the schema
-  - “observation”: a numeric observed value for the unit
+  - "observation": a numeric observed value for the unit
 
 
 ## Some background and an example
@@ -27,29 +27,31 @@
 - What are target keys and how could they be used for this specification?
   - Within each task group, there is a target\_metadata array with one entry per target that is addressed in that task group.
   - Within each of those entries, there is a block that has the form
-    - "Target\_keys": { \<name of task id variable\> : \<task id variable value\> }
-  - Example for a hub that tracks covid cases, hospitalizations, and deaths, recorded via the “target” task id variable:
-    EXAMPLE 1: multiple targets
-    target\_metadata: \[
+    - `"target_keys": { <name of task id variable> : <task id variable value> }`
+  - Example for a hub that tracks covid cases, hospitalizations, and deaths, recorded via the "target" task id variable:
+    EXAMPLE 1: multiple targets:
+    ```json
+    target_metadata: [
         {
-            “Target\_id”: “cases”,
+            "target_id": "cases",
              …,
-            “Target\_keys”: {“target”: “cases”},
+            "target_keys": {"target": "cases"},
             …
         },
         {
-            “Target\_id”: “hospitalizations”,
+            "target_id": "hospitalizations",
              …,
-            “Target\_keys”: {“target”: “hospitalizations”},
+            "target_keys": {"target": "hospitalizations"},
             …
         },
         {
-            “target\_id” : “deaths”,
+            "target_id" : "deaths",
              …,
-            “Target\_keys”: {“target”: “deaths”},
+            "target_keys": {"target": "deaths"},
             …
         }
-    \]
+    ]
+    ```
 
 Then the time-series.csv would look like this
 
@@ -62,33 +64,36 @@ Then the time-series.csv would look like this
 |  | deaths |  |  |  |
 |  | … |  |  |  |
 
-EXAMPLE 2: one target, with target\_keys: null
-target\_metadata: \[
+EXAMPLE 2: one target, with `target_keys: null`
+
+```json
+target_metadata: [
     {
-        “target\_id”: “cases”,
+        "target_id": "cases",
          …,
-        “target\_keys”: null
+        "target_keys": null
         …
     }
-\]
+]
+```
 
 ## Validations
 
 A file hub/target-data/time-series.csv (or .parquet, referred to below as .csv for simplicity) is valid if
 
 1. all model-task blocks in the rounds property of the tasks.json file with the named target-id in target-metadata have
-   1. is\_step\_ahead: true
-   2. target\_type metadata field is one of “continuous” “discrete” “binary” or “compositional”
+   1. `is_step_ahead: true`
+   2. `target_type` metadata field is one of "continuous" "discrete" "binary" or "compositional"
    3. the same task-id variable names
    4. the same task-id variables specified as what define the observable unit (Note: we can only perform this validation if we have a system for indicating which task-id variables define the observable unit. We will not implement this validation to start, but may add it later when schemas are updated.).
 2. The column names of time-series.csv are
-   1. “observation”
+   1. "observation"
    2. The task-id column names that define the observable unit
       1. in our initial implementation, these are defined by the hub admin and not validatable other than that they are task id variable names listed in the hub's `tasks.json` file. At a future time, we could implement a metadata field to capture these so it is validatable.
-   3. (optionally) “as_of”
+   3. (optionally) "as_of"
 3. The [data types](https://hubverse.io/en/latest/user-guide/tasks.html#details) within each column are readable as a consistent data type.
-   1. For “observation” column: readable as numeric
-   2. For “as_of” column: ISO date
+   1. For "observation" column: readable as numeric
+   2. For "as_of" column: ISO date
    3. For other task-id columns: the same data type as the task id variable defined in the tasks.json file.
 4. Values in each task-id column are valid values per the model task definition
    1. Note that some hubs may have different allowable values for different rounds/tasks that have the same target-id. This is ok, and the options here are (1) to have the union of all possible optional/required values be valid values here, or (2) do something more specific based on round-specific values.
@@ -99,7 +104,7 @@ A file hub/target-data/time-series.csv (or .parquet, referred to below as .csv f
 
 This hub’s [tasks.json](https://github.com/cdcepi/FluSight-forecast-hub/blob/main/hub-config/tasks.json) has this structure:
 
-* One round, defined by “reference\_date”
+* One round, defined by "reference\_date"
 * four model\_tasks
   * flu hosp rate change
     * target\_type \= ordinal → observations are labels, not numeric
@@ -121,18 +126,18 @@ This hub’s [tasks.json](https://github.com/cdcepi/FluSight-forecast-hub/blob/m
 So then valid target data would look like
 
 - target-data/time-series.csv (or .parquet)
-  - “as_of” (optional)
-  - “target\_end\_date”
-  - “location”
-  - “target” (this is optional since only one target would be included, but might be good to be explicit)
-  - “observation”: continuous data
+  - "as_of" (optional)
+  - "target\_end\_date"
+  - "location"
+  - "target" (this is optional since only one target would be included, but might be good to be explicit)
+  - "observation": continuous data
 
 ## Example 2: Variant Nowcast Hub
 
 This hub’s [tasks.json](https://github.com/reichlab/variant-nowcast-hub/blob/main/hub-config/tasks.json) has this structure:
 
-* One round defined each week, with only difference being in the options for “clade” each round.
-* Note that this hub has “target\_keys”: null, so there is no explicit “target” column in the model\_output file. It is the only hub that we know of so far that does not have a “target” column.
+* One round defined each week, with only difference being in the options for "clade" each round.
+* Note that this hub has "target\_keys": null, so there is no explicit "target" column in the model\_output file. It is the only hub that we know of so far that does not have a "target" column.
 * one model\_task per round
   * clade prop
     * target\_type \= compositional
@@ -150,11 +155,11 @@ This hub’s [tasks.json](https://github.com/reichlab/variant-nowcast-hub/blob/m
 So then valid target data would look like
 
 - target-data/time-series\_clade-prop.csv (or .parquet)
-  - “as_of” (optional)
-  - “date” (or “target\_end\_date”, depending on whether we can implement a column mapping)
-  - “location”
-  - “clade”
-  - “observation”: continuous data between 0 and 1 inclusive
+  - "as_of" (optional)
+  - "date" (or "target\_end\_date", depending on whether we can implement a column mapping)
+  - "location"
+  - "clade"
+  - "observation": continuous data between 0 and 1 inclusive
 
 ## Alternatives considered
 
@@ -165,7 +170,7 @@ The argument for this is that partitions for target data are premature optimizat
 - We can think of a single example where target data was large enough to possibly warrant a partition (county-level, daily-scale counts for the original US covid-19 forecast hub). In that example, one version of time-series target data for one target had 3m rows of data. The vast majority of other hubs have much smaller target data files.
 - In general, target data files are smaller than model output files because they only need one row for each observation, whereas model output files may have dozens or hundreds of rows for each modeling task. And modeling tasks in different rounds may correspond to the same observation.
 
-However, further discussion showed that to make a single file viable would require using a “diff” strategy to store only updated values. This leads to substantial accessibility issues, where additional processing would be needed to read even a single version of the time-series data.
+However, further discussion showed that to make a single file viable would require using a "diff" strategy to store only updated values. This leads to substantial accessibility issues, where additional processing would be needed to read even a single version of the time-series data.
 
 ### Supporting multiple single files, one per target
 
@@ -173,7 +178,7 @@ It was agreed that this is the least accessible option. It would always require 
 
 ### Adding a new schema property to define the observed unit variables
 
-The idea here would be to add a new schema property that defines which task-id variables correspond to the variables that define the observational unit. This mapping could also allow for renaming certain variables, e.g. task-id variable of “target\_end\_date” could just be “date” which would be more natural in the context of a time-series target data file.
+The idea here would be to add a new schema property that defines which task-id variables correspond to the variables that define the observational unit. This mapping could also allow for renaming certain variables, e.g. task-id variable of "target\_end\_date" could just be "date" which would be more natural in the context of a time-series target data file.
 
 This is something that we would like to do at some point, but doesn’t feel essential to making this work in the short term.
 


### PR DESCRIPTION
The JSON was not easy to read because it was not formatted correctly.
This fixes that issue and replaces "smart" quotes with regular quotes
